### PR TITLE
Corrected http response code for create user api

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -48,7 +48,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           
-      - name: Run tests with Pytest
+      - name: Run tests with Pytest with Coverage
         env:
           DATABASE_URL: postgresql+asyncpg://user:password@localhost:5432/myappdb
         run: pytest

--- a/app/routers/user_routes.py
+++ b/app/routers/user_routes.py
@@ -109,7 +109,7 @@ async def delete_user(user_id: UUID, db: AsyncSession = Depends(get_async_db), t
 
 
 
-@router.post("/users/", response_model=UserResponse, status_code=status.HTTP_201_CREATED, tags=["User Management"], name="create_user")
+@router.post("/users/", response_model=UserResponse, status_code=status.HTTP_200_OK, tags=["User Management"], name="create_user")
 async def create_user(user: UserCreate, request: Request, db: AsyncSession = Depends(get_async_db), token: str = Depends(oauth2_scheme)):
     """
     Create a new user.

--- a/tests/test_api/test_users_api.py
+++ b/tests/test_api/test_users_api.py
@@ -28,7 +28,7 @@ async def test_create_user(async_client):
     response = await async_client.post("/users/", json=user_data, headers=headers)
 
     # Asserts
-    assert response.status_code == 201
+    assert response.status_code == 200
 
 # You can similarly refactor other test functions to use the async_client fixture
 @pytest.mark.asyncio


### PR DESCRIPTION
The attribute "status_code=status.HTTP_201_CREATED" for create user api was changed to "status_code=status.HTTP_200_OK" in user_routes.py and "assert response.status_code == 201" was changed to "assert response.status_code == 200" in test_users_api.py